### PR TITLE
Update kclient.c

### DIFF
--- a/api_c/kclient.c
+++ b/api_c/kclient.c
@@ -152,18 +152,18 @@ void free_command(struct command *cmd)
 
 #define CMD_LEN 1024
 
-#define CHECK_FORMAT(ret)               \
-  do {                                  \
-  if ((ret) < 0) {                      \
-      DEBUG_MSG("Format error\n");      \
-      return -1;                        \
-  }                                     \
-                                        \
-  if ((ret) >= CMD_LEN) {               \
-      DEBUG_MSG("Buffer overflow\n");   \
-      return -1;                        \
-  }                                     \
-  while(0)
+#define CHECK_FORMAT(ret)                   \
+  do {                                      \
+      if ((ret) < 0) {                      \
+          DEBUG_MSG("Format error\n");      \
+          return -1;                        \
+      }                                     \
+                                            \
+      if ((ret) >= CMD_LEN) {               \
+          DEBUG_MSG("Buffer overflow\n");   \
+          return -1;                        \
+      }                                     \
+  } while(0)
 
 static int build_command_string(struct command *cmd, char *cmd_str)
 {

--- a/api_c/kclient.c
+++ b/api_c/kclient.c
@@ -153,6 +153,7 @@ void free_command(struct command *cmd)
 #define CMD_LEN 1024
 
 #define CHECK_FORMAT(ret)               \
+  do {                                  \
   if ((ret) < 0) {                      \
       DEBUG_MSG("Format error\n");      \
       return -1;                        \
@@ -161,23 +162,24 @@ void free_command(struct command *cmd)
   if ((ret) >= CMD_LEN) {               \
       DEBUG_MSG("Buffer overflow\n");   \
       return -1;                        \
-  }
+  }                                     \
+  while(0)
 
 static int build_command_string(struct command *cmd, char *cmd_str)
 {
     int i;    
     int ret = snprintf(cmd_str, CMD_LEN, "%i|%i|", 
                        cmd->dev_id, cmd->op_ref);          
-    CHECK_FORMAT(ret)
+    CHECK_FORMAT(ret);
     
     for (i=0; i<cmd->params_num; i++) {
         ret = snprintf(cmd_str + strlen(cmd_str), CMD_LEN, "%lu|", 
                        (cmd->params)[i]);
-        CHECK_FORMAT(ret)
+        CHECK_FORMAT(ret);
     }
     
     ret = snprintf(cmd_str+strlen(cmd_str), CMD_LEN, "\n");
-    CHECK_FORMAT(ret)
+    CHECK_FORMAT(ret);
     
     return 0;
 }


### PR DESCRIPTION
Using do { } while(0) in a macro helps the code to behave correctly, even if the user writes this such as an inline block:

```
if(...) CHECK_FORMAT(ret);
```

See also: http://stackoverflow.com/questions/1067226/c-multi-line-macro-do-while0-vs-scope-block

This pull request does not correct a problem, but may prevent difficulties to understand execution time errors in the future. I only applied the correction once, but all your macros have the same imperfection.
